### PR TITLE
Allow typing vector arguments on command callables

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -613,7 +613,10 @@ func _are_compatible_types(p_expected_type: int, p_parsed_type: int) -> bool:
 	return p_expected_type == p_parsed_type or \
 		p_expected_type == TYPE_NIL or \
 		p_expected_type == TYPE_STRING or \
-		p_expected_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT] and p_parsed_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT]
+		(p_expected_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT] and p_parsed_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT]) or \
+		(p_expected_type in [TYPE_VECTOR2, TYPE_VECTOR2I] and p_parsed_type in [TYPE_VECTOR2, TYPE_VECTOR2I]) or \
+		(p_expected_type in [TYPE_VECTOR3, TYPE_VECTOR3I] and p_parsed_type in [TYPE_VECTOR3, TYPE_VECTOR3I]) or \
+		(p_expected_type in [TYPE_VECTOR4, TYPE_VECTOR4I] and p_parsed_type in [TYPE_VECTOR4, TYPE_VECTOR4I])
 
 
 func _parse_vector_arg(p_text):
@@ -771,7 +774,7 @@ func _validate_callable(p_callable: Callable) -> bool:
 
 	var ret := true
 	for arg in method_info.args:
-		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING]:
+		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:
 			push_error("LimboConsole: Unsupported argument type: %s is %s" % [arg.name, type_string(arg.type)])
 			ret = false
 	return ret


### PR DESCRIPTION
Without this PR, you'll get an error if you try to use a callable that types its vector arguments, for example:

```
func spawn_entity(p_entity_name: String, p_position: Vector2i) -> void:
    pass
```

However, with this PR, there won't be an error and it'll work correctly!