### PR TITLE
Add animation to open/close console.

### DIFF
--- a/console_options.gd
+++ b/console_options.gd
@@ -13,6 +13,7 @@ const CONFIG_PATH := "res://addons/limbo_console.cfg"
 @export_category("appearance")
 @export var custom_theme: String = "res://addons/limbo_console_theme.tres"
 @export var height_ratio: float = 0.5
+@export var open_speed: float = 5.0 # For instant, set to a really high float like 99999.0
 @export var opacity: float = 1.0
 @export var sparse_mode: bool = false # Print empty line after each command execution.
 


### PR DESCRIPTION
Notes on implementation:
- Despite animating open, it will immediately pause the game and grab UI focus for the text prompt and accept input.
- Console only unpauses and hides when done animating, but stops accepting input while closing.
- You can toggle at any point of the animation, it will start going the other way. 
- Progress of animation is a linear 0 to 1, but is eased with a hardcoded value. It could be exposed to the user to customize. 
- User can set open speed from the config file. Note that it closes faster than opening, which is currently hardcoded.
- `show_console()` and `hide_console()` are moved to private, replaced by `open_console()` and `close_console()`.

Initially it was a bit more messy, but I cleaned it up and use two new functions to toggle the animation while keeping the show/hide functions the same.

<details>
<summary>Out of Date Comment</summary>
Show/hide functions should be fine if anyone calls them directly, I added several checks around new logic so they wouldn't have issues. Personally though, I would move show/hide to 'private' to avoid confusion, but I know interface changes can be annoying.
</details>