### PR TITLE
Add functions for providing base instance for eval commands

### DIFF
--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -104,7 +104,8 @@ static func cmd_eval(p_expression: String) -> Error:
 	if err != OK:
 		LimboConsole.error(exp.get_error_text())
 		return err
-	var result = exp.execute(LimboConsole.get_eval_inputs())
+	var result = exp.execute(LimboConsole.get_eval_inputs(),
+		LimboConsole.get_eval_base_instance())
 	if not exp.has_execute_failed():
 		if result != null:
 			LimboConsole.info(str(result))

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -453,6 +453,18 @@ func get_eval_inputs() -> Array:
 	return _eval_inputs.values()
 
 
+## Define the object that will be used as the base instance for "eval" command.
+## Can be null (the default) to not use any base instance.
+func set_eval_base_instance(object):
+	_eval_inputs["_base_instance"] = object
+
+
+## Get the object that will be used as the base instance for "eval" command.
+## Null by default.
+func get_eval_base_instance():
+	return _eval_inputs.get("_base_instance")
+
+
 # *** PRIVATE
 
 # *** INITIALIZATION

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -454,6 +454,7 @@ func get_eval_inputs() -> Array:
 
 
 ## Define the object that will be used as the base instance for "eval" command.
+## When defined, this object will be the "self" for expressions.
 ## Can be null (the default) to not use any base instance.
 func set_eval_base_instance(object):
 	_eval_inputs["_base_instance"] = object


### PR DESCRIPTION
This adds two functions to LimboConsole: `set_eval_base_instance` and `get_eval_base_instance`. When set, the `eval` command will pass the provided object as the `base_instance` param to the evaluator.
By default there is none set, which matches the current behavior.

As an example, I can do this after passing my game scene root to `LimboConsole.set_eval_base_instance()`:
<img width="542" alt="image" src="https://github.com/user-attachments/assets/1b06d8e0-2105-4edc-a546-9e506efba9d0" />
