### PR TITLE
Migrate to 4.4

### DIFF
--- a/ascii_art.gd.uid
+++ b/ascii_art.gd.uid
@@ -1,0 +1,1 @@
+uid://cn3jn3jy0tlto

--- a/builtin_commands.gd.uid
+++ b/builtin_commands.gd.uid
@@ -1,0 +1,1 @@
+uid://bbqobpy0ivncg

--- a/command_entry.gd.uid
+++ b/command_entry.gd.uid
@@ -1,0 +1,1 @@
+uid://cfhxv84721gbk

--- a/config_mapper.gd.uid
+++ b/config_mapper.gd.uid
@@ -1,0 +1,1 @@
+uid://cjouodatpo0o0

--- a/console_options.gd.uid
+++ b/console_options.gd.uid
@@ -1,0 +1,1 @@
+uid://dyhclikh4srxs

--- a/limbo_console.gd.uid
+++ b/limbo_console.gd.uid
@@ -1,0 +1,1 @@
+uid://bldy5uihfdisk

--- a/plugin.gd.uid
+++ b/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://dmvtb01r4q2c8

--- a/res/fonts/monaspace_argon_bold.otf.import
+++ b/res/fonts/monaspace_argon_bold.otf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/res/fonts/monaspace_argon_bold_italic.otf.import
+++ b/res/fonts/monaspace_argon_bold_italic.otf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/res/fonts/monaspace_argon_italic.otf.import
+++ b/res/fonts/monaspace_argon_italic.otf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/res/fonts/monaspace_argon_medium.otf.import
+++ b/res/fonts/monaspace_argon_medium.otf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/res/fonts/monaspace_argon_regular.otf.import
+++ b/res/fonts/monaspace_argon_regular.otf.import
@@ -23,6 +23,7 @@ allow_system_fallback=true
 force_autohinter=false
 hinting=1
 subpixel_positioning=1
+keep_rounding_remainders=true
 oversampling=0.0
 Fallbacks=null
 fallbacks=[]

--- a/util.gd.uid
+++ b/util.gd.uid
@@ -1,0 +1,1 @@
+uid://dyjgmqsocaoi1


### PR DESCRIPTION
Hi,

I've committed the generated .uid files to the repository, along with some other automated changes that occurred when opening the project in Godot 4.4.

Based on a discussion in the Godot Discord, even addons and plugins should have their resource .uid files committed.

![grafik](https://github.com/user-attachments/assets/ffdd6ec9-5d8c-4e6d-b4b2-7e36a98aac33)

In the long run, migrating to using UIDs in paths would be an even better solution, but that would require a more significant change.
