### PR TITLE
Show auto complete values in usage command

### DIFF
--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -16,7 +16,6 @@ static func register_commands() -> void:
 	LimboConsole.register_command(cmd_fps_max, "fps_max", "limit framerate")
 	LimboConsole.register_command(cmd_fullscreen, "fullscreen", "toggle fullscreen mode")
 	LimboConsole.register_command(cmd_help, "help", "show command info")
-	LimboConsole.register_command(cmd_help_with_args, "help_with_args", "show command info with values from auto-complete sources listed")
 	LimboConsole.register_command(cmd_log, "log", "show recent log entries")
 	LimboConsole.register_command(cmd_quit, "quit", "exit the application")
 	LimboConsole.register_command(cmd_unalias, "unalias", "remove command alias")
@@ -160,16 +159,6 @@ static func cmd_help(p_command_name: String = "") -> Error:
 		return OK
 	else:
 		return LimboConsole.usage(p_command_name)
-		
-static func cmd_help_with_args(p_command_name: String = "") -> Error:
-	if p_command_name.is_empty():
-		LimboConsole.print_line(LimboConsole.format_tip("Type %s to list all available commands." %
-				[LimboConsole.format_name("commands")]))
-		LimboConsole.print_line(LimboConsole.format_tip("Type %s to get more info about the command." %
-				[LimboConsole.format_name("help command")]))
-		return OK
-	else:
-		return LimboConsole.usage(p_command_name, true)
 
 
 static func cmd_log(p_num_lines: int = 10) -> Error:

--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -16,6 +16,7 @@ static func register_commands() -> void:
 	LimboConsole.register_command(cmd_fps_max, "fps_max", "limit framerate")
 	LimboConsole.register_command(cmd_fullscreen, "fullscreen", "toggle fullscreen mode")
 	LimboConsole.register_command(cmd_help, "help", "show command info")
+	LimboConsole.register_command(cmd_help_with_args, "help_with_args", "show command info with valid arguments")
 	LimboConsole.register_command(cmd_log, "log", "show recent log entries")
 	LimboConsole.register_command(cmd_quit, "quit", "exit the application")
 	LimboConsole.register_command(cmd_unalias, "unalias", "remove command alias")
@@ -96,6 +97,7 @@ static func cmd_commands() -> void:
 		var desc: String = LimboConsole.get_command_description(name)
 		name = LimboConsole.format_name(name)
 		LimboConsole.info(name if desc.is_empty() else "%s -- %s" % [name, desc])
+	
 
 
 static func cmd_eval(p_expression: String) -> Error:
@@ -158,6 +160,16 @@ static func cmd_help(p_command_name: String = "") -> Error:
 		return OK
 	else:
 		return LimboConsole.usage(p_command_name)
+		
+static func cmd_help_with_args(p_command_name: String = "") -> Error:
+	if p_command_name.is_empty():
+		LimboConsole.print_line(LimboConsole.format_tip("Type %s to list all available commands." %
+				[LimboConsole.format_name("commands")]))
+		LimboConsole.print_line(LimboConsole.format_tip("Type %s to get more info about the command." %
+				[LimboConsole.format_name("help command")]))
+		return OK
+	else:
+		return LimboConsole.usage(p_command_name, true)
 
 
 static func cmd_log(p_num_lines: int = 10) -> Error:

--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -16,7 +16,7 @@ static func register_commands() -> void:
 	LimboConsole.register_command(cmd_fps_max, "fps_max", "limit framerate")
 	LimboConsole.register_command(cmd_fullscreen, "fullscreen", "toggle fullscreen mode")
 	LimboConsole.register_command(cmd_help, "help", "show command info")
-	LimboConsole.register_command(cmd_help_with_args, "help_with_args", "show command info with valid arguments")
+	LimboConsole.register_command(cmd_help_with_args, "help_with_args", "show command info with values from auto-complete sources listed")
 	LimboConsole.register_command(cmd_log, "log", "show recent log entries")
 	LimboConsole.register_command(cmd_quit, "quit", "exit the application")
 	LimboConsole.register_command(cmd_unalias, "unalias", "remove command alias")

--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -96,7 +96,6 @@ static func cmd_commands() -> void:
 		var desc: String = LimboConsole.get_command_description(name)
 		name = LimboConsole.format_name(name)
 		LimboConsole.info(name if desc.is_empty() else "%s -- %s" % [name, desc])
-	
 
 
 static func cmd_eval(p_expression: String) -> Error:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -427,7 +427,7 @@ func usage(p_command: String) -> Error:
 		
 		if _argument_autocomplete_sources.has([p_command, i + 1]):
 			var auto_complete_callable: Callable = _argument_autocomplete_sources[[p_command, i + 1]]
-			var arg_autocompletes: Array = auto_complete_callable.call()
+			var arg_autocompletes = auto_complete_callable.call()
 			if len(arg_autocompletes) > 0:
 				var values: String = str(arg_autocompletes).replace("[", "").replace("]", "")
 				values_lines += " %s: %s\n" % [arg_name, values]

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -427,10 +427,11 @@ func usage(p_command: String) -> Error:
 		
 		if _argument_autocomplete_sources.has([p_command, i + 1]):
 			var auto_complete_callable = _argument_autocomplete_sources[[p_command, i + 1]]
-			var arg_autocompletes = auto_complete_callable.call()
+			var auto_complete_callable: Callable = _argument_autocomplete_sources[[p_command, i + 1]]
+			var arg_autocompletes: Array = auto_complete_callable.call()
 			if len(arg_autocompletes) > 0:
-				var val = str(arg_autocompletes).replace("[", "").replace("]", "")
-				values_lines += " %s: %s\n" % [arg_name, val]
+				var values: String = str(arg_autocompletes).replace("[", "").replace("]", "")
+				values_lines += " %s: %s\n" % [arg_name, values]
 	arg_lines = arg_lines.trim_suffix('\n')
 
 	print_line(usage_line)

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -426,7 +426,6 @@ func usage(p_command: String) -> Error:
 		arg_lines += "  %s: %s%s\n" % [arg_name, type_string(arg_type) if arg_type != TYPE_NIL else "Variant", def_spec]
 		
 		if _argument_autocomplete_sources.has([p_command, i + 1]):
-			var auto_complete_callable = _argument_autocomplete_sources[[p_command, i + 1]]
 			var auto_complete_callable: Callable = _argument_autocomplete_sources[[p_command, i + 1]]
 			var arg_autocompletes: Array = auto_complete_callable.call()
 			if len(arg_autocompletes) > 0:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -387,7 +387,7 @@ func format_name(p_name: String) -> String:
 
 
 ## Prints the help text for the given command.
-func usage(p_command: String, with_autocomplete_vals: bool = false) -> Error:
+func usage(p_command: String) -> Error:
 	if _aliases.has(p_command):
 		var alias_argv: PackedStringArray = get_alias_argv(p_command)
 		var formatted_cmd := "%s %s" % [format_name(alias_argv[0]), ' '.join(alias_argv.slice(1))]
@@ -425,7 +425,7 @@ func usage(p_command: String, with_autocomplete_vals: bool = false) -> Error:
 			def_spec = " = %s" % [def_value]
 		arg_lines += "  %s: %s%s\n" % [arg_name, type_string(arg_type) if arg_type != TYPE_NIL else "Variant", def_spec]
 		
-		if with_autocomplete_vals && _argument_autocomplete_sources.has([p_command, i + 1]):
+		if _argument_autocomplete_sources.has([p_command, i + 1]):
 			var auto_complete_callable = _argument_autocomplete_sources[[p_command, i + 1]]
 			var arg_autocompletes = auto_complete_callable.call()
 			if len(arg_autocompletes) > 0:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -387,7 +387,7 @@ func format_name(p_name: String) -> String:
 
 
 ## Prints the help text for the given command.
-func usage(p_command: String) -> Error:
+func usage(p_command: String, with_autocomplete_vals: bool = false) -> Error:
 	if _aliases.has(p_command):
 		var alias_argv: PackedStringArray = get_alias_argv(p_command)
 		var formatted_cmd := "%s %s" % [format_name(alias_argv[0]), ' '.join(alias_argv.slice(1))]
@@ -406,6 +406,7 @@ func usage(p_command: String) -> Error:
 
 	var usage_line: String = "Usage: %s" % [p_command]
 	var arg_lines: String = ""
+	var values_lines: String = ""
 	var required_args: int = method_info.args.size() - method_info.default_args.size()
 
 	for i in range(method_info.args.size() - callable.get_bound_arguments_count()):
@@ -423,6 +424,13 @@ func usage(p_command: String) -> Error:
 				def_value = "\"" + def_value + "\""
 			def_spec = " = %s" % [def_value]
 		arg_lines += "  %s: %s%s\n" % [arg_name, type_string(arg_type) if arg_type != TYPE_NIL else "Variant", def_spec]
+		
+		if with_autocomplete_vals && _argument_autocomplete_sources.has([p_command, i + 1]):
+			var auto_complete_callable = _argument_autocomplete_sources[[p_command, i + 1]]
+			var arg_autocompletes = auto_complete_callable.call()
+			if len(arg_autocompletes) > 0:
+				var val = str(arg_autocompletes).replace("[", "").replace("]", "")
+				values_lines += " %s: %s\n" % [arg_name, val]
 	arg_lines = arg_lines.trim_suffix('\n')
 
 	print_line(usage_line)
@@ -438,6 +446,10 @@ func usage(p_command: String) -> Error:
 	if not arg_lines.is_empty():
 		print_line("Arguments:")
 		print_line(arg_lines)
+		
+	if not values_lines.is_empty():
+		print_line("Values:")
+		print_line(values_lines)
 	return OK
 
 

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -424,7 +424,6 @@ func usage(p_command: String) -> Error:
 				def_value = "\"" + def_value + "\""
 			def_spec = " = %s" % [def_value]
 		arg_lines += "  %s: %s%s\n" % [arg_name, type_string(arg_type) if arg_type != TYPE_NIL else "Variant", def_spec]
-		
 		if _argument_autocomplete_sources.has([p_command, i + 1]):
 			var auto_complete_callable: Callable = _argument_autocomplete_sources[[p_command, i + 1]]
 			var arg_autocompletes = auto_complete_callable.call()
@@ -446,7 +445,6 @@ func usage(p_command: String) -> Error:
 	if not arg_lines.is_empty():
 		print_line("Arguments:")
 		print_line(arg_lines)
-		
 	if not values_lines.is_empty():
 		print_line("Values:")
 		print_line(values_lines)


### PR DESCRIPTION
Updates `usage` to take an optional parameter to print autocomplete sources. Would resolve #17 . I am open to removing the new command and the optional parameter added to `usage` and instead always printing the auto-complete sources under the 'Values' header. Here is what it looks like:

![image](https://github.com/user-attachments/assets/e2e6bc8f-14c3-47eb-b791-bb9be65d40fc)
