### PR TITLE
Option to use history in argument auto-completion

### DIFF
--- a/config_mapper.gd
+++ b/config_mapper.gd
@@ -7,7 +7,7 @@ const CONFIG_PATH_PROPERTY := &"CONFIG_PATH"
 const MAIN_SECTION_PROPERTY := &"MAIN_SECTION"
 const MAIN_SECTION_DEFAULT := "main"
 
-static var verbose: bool = true
+static var verbose: bool = false
 
 static func _get_config_file(p_object: Object) -> String:
 	var from_object_constant = p_object.get(CONFIG_PATH_PROPERTY)

--- a/config_mapper.gd
+++ b/config_mapper.gd
@@ -7,7 +7,7 @@ const CONFIG_PATH_PROPERTY := &"CONFIG_PATH"
 const MAIN_SECTION_PROPERTY := &"MAIN_SECTION"
 const MAIN_SECTION_DEFAULT := "main"
 
-static var verbose: bool = false
+static var verbose: bool = true
 
 static func _get_config_file(p_object: Object) -> String:
 	var from_object_constant = p_object.get(CONFIG_PATH_PROPERTY)

--- a/console_options.gd
+++ b/console_options.gd
@@ -31,6 +31,9 @@ const CONFIG_PATH := "res://addons/limbo_console.cfg"
 @export var persist_history: bool = true
 @export var history_lines: int = 1000
 
+@export_category("autocomplete")
+@export var autocomplete_use_history: bool = true
+
 @export_category("autoexec")
 @export var autoexec_script: String = "user://autoexec.lcs"
 @export var autoexec_auto_create: bool = true

--- a/console_options.gd
+++ b/console_options.gd
@@ -32,7 +32,7 @@ const CONFIG_PATH := "res://addons/limbo_console.cfg"
 @export var history_lines: int = 1000
 
 @export_category("autocomplete")
-@export var autocomplete_use_history: bool = true
+@export var autocomplete_use_history_with_matches: bool = true
 
 @export_category("autoexec")
 @export var autoexec_script: String = "user://autoexec.lcs"

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -802,6 +802,12 @@ func _update_autocomplete() -> void:
 						matches.append(_entry.text.substr(0, _entry.text.length() - argv[last_arg].length()) + str(value))
 				matches.sort()
 				_autocomplete_matches.append_array(matches)
+			# History
+			if _options.autocomplete_use_history or \
+			 		not _argument_autocomplete_sources.has(key):
+				for i in range(_history.size() - 1, -1, -1):
+					if _history[i].begins_with(_entry.text):
+						_autocomplete_matches.append(_history[i])
 
 	if _autocomplete_matches.size() > 0 \
 			and _autocomplete_matches[0].length() > _entry.text.length() \

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -802,10 +802,6 @@ func _update_autocomplete() -> void:
 						matches.append(_entry.text.substr(0, _entry.text.length() - argv[last_arg].length()) + str(value))
 				matches.sort()
 				_autocomplete_matches.append_array(matches)
-			# History
-			for i in range(_history.size() - 1, -1, -1):
-				if _history[i].begins_with(_entry.text):
-					_autocomplete_matches.append(_history[i])
 
 	if _autocomplete_matches.size() > 0 \
 			and _autocomplete_matches[0].length() > _entry.text.length() \

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -804,6 +804,7 @@ func _update_autocomplete() -> void:
 				_autocomplete_matches.append_array(matches)
 			# History
 			if _options.autocomplete_use_history_with_matches or \
+			 		len(_autocomplete_matches) == 0:
 				for i in range(_history.size() - 1, -1, -1):
 					if _history[i].begins_with(_entry.text):
 						_autocomplete_matches.append(_history[i])

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -803,8 +803,7 @@ func _update_autocomplete() -> void:
 				matches.sort()
 				_autocomplete_matches.append_array(matches)
 			# History
-			if _options.autocomplete_use_history or \
-			 		not _argument_autocomplete_sources.has(key):
+			if _options.autocomplete_use_history_with_matches or \
 				for i in range(_history.size() - 1, -1, -1):
 					if _history[i].begins_with(_entry.text):
 						_autocomplete_matches.append(_history[i])


### PR DESCRIPTION
Removes pulling from history while tabbing leaving history to only the up and down arrow keys. Fixes #16  