### PR TITLE
Tabs through all auto-complete sources

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -775,7 +775,7 @@ func _update_autocomplete() -> void:
 		else:
 			# Arguments
 			var key := [command_name, last_arg]
-			if _argument_autocomplete_sources.has(key) and not argv[last_arg].is_empty():
+			if _argument_autocomplete_sources.has(key):
 				var argument_values = _argument_autocomplete_sources[key].call()
 				if typeof(argument_values) < TYPE_ARRAY:
 					push_error("LimboConsole: Argument autocomplete source returned unsupported type: ",


### PR DESCRIPTION
Allows tabbing through all options of an auto-complete source when the argument is empty. Fixes #19 

 This should still keep the functionality of filtering down to commands that starts with what the user typed from my testing. I think it improves the usability quite a bit and makes the auto-complete sources even more valuable
 
 

https://github.com/user-attachments/assets/a35e6e27-86aa-4323-9763-7087e67510c9

