### PR TITLE
Added echo input handling to console _input

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -96,10 +96,7 @@ func _exit_tree() -> void:
 	if _options.persist_history:
 		_save_history()
 
-
 func _input(p_event: InputEvent) -> void:
-	if p_event.is_echo():
-		return
 	if p_event.is_action_pressed("limbo_console_toggle"):
 		toggle_console()
 		get_viewport().set_input_as_handled()

--- a/util.gd.uid
+++ b/util.gd.uid
@@ -1,1 +1,0 @@
-uid://ujxny15gg8p2

--- a/util.gd.uid
+++ b/util.gd.uid
@@ -1,0 +1,1 @@
+uid://ujxny15gg8p2


### PR DESCRIPTION
Removed code preventing the input processing from running if an input event was an echo event. Allowing the input processing fixes an issue where the user would hold tab for auto-complete and have tabs start to be entered into the text edit. Also fixes an issue where you could not hold up or down arrow keys to go through history quickly. Previously you would have to release and repress the input. Fixes #24 


In the video below in the first half I am pressing and holding tab and able to quickly go through all the options. In the second half of the video I am pressing and holding the down arrow keys to get the history of my commands:

https://github.com/user-attachments/assets/1abbef0e-a425-47e8-b52a-325c24a3f31c

