### PR TITLE
Add registering commands with bound arguments

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -400,7 +400,7 @@ func usage(p_command: String) -> Error:
 	var arg_lines: String = ""
 	var required_args: int = method_info.args.size() - method_info.default_args.size()
 
-	for i in range(method_info.args.size()):
+	for i in range(method_info.args.size() - callable.get_bound_arguments_count()):
 		var arg_name: String = method_info.args[i].name.trim_prefix("p_")
 		var arg_type: int = method_info.args[i].type
 		if i < required_args:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -641,8 +641,8 @@ func _parse_argv(p_argv: PackedStringArray, p_callable: Callable, r_args: Array)
 	if method_info.is_empty():
 		error("Couldn't find method info for: " + p_callable.get_method())
 		return false
-
-	var num_args: int = p_argv.size() - 1
+	var num_bound_args: int = p_callable.get_bound_arguments_count()
+	var num_args: int = p_argv.size() + num_bound_args - 1
 	var max_args: int = method_info.args.size()
 	var num_with_defaults: int = method_info.default_args.size()
 	var required_args: int = max_args - num_with_defaults
@@ -883,6 +883,7 @@ func _validate_callable(p_callable: Callable) -> bool:
 	if method_info.is_empty():
 		push_error("LimboConsole: Couldn't find method info for: " + p_callable.get_method())
 		return false
+
 
 	var ret := true
 	for arg in method_info.args:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -884,7 +884,6 @@ func _validate_callable(p_callable: Callable) -> bool:
 		push_error("LimboConsole: Couldn't find method info for: " + p_callable.get_method())
 		return false
 
-
 	var ret := true
 	for arg in method_info.args:
 		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:


### PR DESCRIPTION
Added registering commands with bound arguments. Fixes #8 

Additionally this was some code that I used to test the binding out:

```gdscript
    
    # ---- Bound Command Test ----
    LimboConsole.register_command(_bound_command_test.bind(true), "bound_command_test", "a test command for using bind for a callable")
    # The bound arguments are bound right to left
    # i.e. - last parameter for the method should be the first bound
    LimboConsole.register_command(_bound_command_test_multi_arg.bind(1).bind("ABC"), "bound_command_multi_test", "Testing a multi-argument bound command")
    # Here we are binding only one argument and we expect the user to supply the first argument of the callable
    LimboConsole.register_command(_bound_command_test_multi_arg.bind(32), "bound_command_multi_test_2", "Testing one input from command line one from bound argument")
    
    # Bindv binds how you would expect - left to right
    LimboConsole.register_command(_bound_command_test_multi_arg.bindv(["ABC", 32]), "bound_command_multi_test_3")
    # ... unless you are wanting to chain binds
    LimboConsole.register_command(_bound_command_test_multi_arg.bindv([32]).bindv(["ABC"]), "bound_command_multi_test_4")
    # ... or unless you are wanting some inputs supplied from the command line
    # Here we are binding only one argument and we expect the user to supply the first argument of the callable
    LimboConsole.register_command(_bound_command_test_multi_arg.bindv([32]), "bound_command_multi_test_5")
 

static func _bound_command_test(val: bool):
    LimboConsole.info("val: %s" % [val])

static func _bound_command_test_multi_arg(val: String, num: int) -> void:
    LimboConsole.info("val: %s | num: %s" % [val, num])
   
```

This also updates the help command to show only arguments that must be typed by the user (aka unbound arguments)