### PR TITLE
Add reversing auto-complete

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -98,8 +98,6 @@ func _exit_tree() -> void:
 
 
 func _input(p_event: InputEvent) -> void:
-	if p_event.is_echo():
-		return
 	if p_event.is_action_pressed("limbo_console_toggle"):
 		toggle_console()
 		get_viewport().set_input_as_handled()
@@ -113,6 +111,8 @@ func _input(p_event: InputEvent) -> void:
 		elif p_event.keycode == KEY_DOWN:
 			_hist_idx -= 1
 			_fill_entry_from_history()
+		elif p_event.is_action_pressed("limbo_auto_complete_reverse"):
+			_reverse_autocomplete()
 		elif p_event.keycode == KEY_TAB:
 			_autocomplete()
 		elif p_event.keycode == KEY_PAGEUP:
@@ -745,17 +745,24 @@ func _parse_vector_arg(p_text):
 
 # *** AUTOCOMPLETE
 
-
 ## Auto-completes a command or auto-correction on TAB.
 func _autocomplete() -> void:
 	if not _autocomplete_matches.is_empty():
-		var match: String = _autocomplete_matches[0]
-		_fill_entry(match)
+		var match_str: String = _autocomplete_matches[0]
+		_fill_entry(match_str)
 		_autocomplete_matches.remove_at(0)
-		_autocomplete_matches.push_back(match)
+		_autocomplete_matches.push_back(match_str)
 		_update_autocomplete()
-
-
+		
+func _reverse_autocomplete():
+	if not _autocomplete_matches.is_empty():
+		var match_str = _autocomplete_matches[_autocomplete_matches.size() - 1]
+		_autocomplete_matches.remove_at(_autocomplete_matches.size() - 1)
+		_autocomplete_matches.insert(0, match_str)
+		match_str = _autocomplete_matches[_autocomplete_matches.size() - 1]
+		_fill_entry(match_str)
+		_update_autocomplete()
+		
 ## Updates autocomplete suggestions and hint based on user input.
 func _update_autocomplete() -> void:
 	var argv: PackedStringArray = _expand_alias(_parse_command_line(_entry.text))

--- a/plugin.gd
+++ b/plugin.gd
@@ -27,13 +27,13 @@ func _enter_tree() -> void:
 		
 	if not ProjectSettings.has_setting("input/limbo_auto_complete_reverse"):
 		print("LimboConsole: Adding \"limbo_auto_complete_reverse\" input action to project settings...")
-		var reverse_autocomplete_key_event = InputEventKey.new()
-		reverse_autocomplete_key_event.keycode = KEY_TAB
-		reverse_autocomplete_key_event.shift_pressed = true
+		var key_event = InputEventKey.new()
+		key_event.keycode = KEY_TAB
+		key_event.shift_pressed = true
 		
 		ProjectSettings.set_setting("input/limbo_auto_complete_reverse", {
 			"deadzone": 0.5,
-			"events": [reverse_autocomplete_key_event],
+			"events": [key_event],
 		})
 		do_project_setting_save = true
 		

--- a/plugin.gd
+++ b/plugin.gd
@@ -9,6 +9,7 @@ func _enter_tree() -> void:
 
 	# Sync config file (create if not exists)
 	var console_options := ConsoleOptions.new()
+	var do_project_setting_save: bool = false
 	ConfigMapper.load_from_config(console_options)
 	ConfigMapper.save_to_config(console_options)
 
@@ -22,6 +23,21 @@ func _enter_tree() -> void:
 			"deadzone": 0.5,
 			"events": [key_event],
 		})
+		do_project_setting_save = true
+		
+	if not ProjectSettings.has_setting("input/limbo_auto_complete_reverse"):
+		print("LimboConsole: Adding \"limbo_auto_complete_reverse\" input action to project settings...")
+		var reverse_autocomplete_key_event = InputEventKey.new()
+		reverse_autocomplete_key_event.keycode = KEY_TAB
+		reverse_autocomplete_key_event.shift_pressed = true
+		
+		ProjectSettings.set_setting("input/limbo_auto_complete_reverse", {
+			"deadzone": 0.5,
+			"events": [reverse_autocomplete_key_event],
+		})
+		do_project_setting_save = true
+		
+	if do_project_setting_save:
 		ProjectSettings.save()
 
 


### PR DESCRIPTION
Adds reversing auto-complete when the input 'limbo_auto_complete_reverse" (default shift + tab) is pressed while typing in the console. Fixes #28 