### PR TITLE
Option to specify commands disabled in release & disable eval

### DIFF
--- a/console_options.gd
+++ b/console_options.gd
@@ -11,6 +11,10 @@ const CONFIG_PATH := "res://addons/limbo_console.cfg"
 @export var disable_in_release_build: bool = false
 @export var print_to_stdout: bool = false
 
+@export var commands_disabled_in_release: PackedStringArray = [
+	"eval" # enables arbitrary code execution and asset extraction in the running game.
+]
+
 @export_category("appearance")
 @export var custom_theme: String = "res://addons/limbo_console_theme.tres"
 @export var height_ratio: float = 0.5

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -225,6 +225,8 @@ func register_command(p_func: Callable, p_name: String = "", p_desc: String = ""
 			push_error("LimboConsole: Failed to register command: Callable is not method and no name was provided")
 			return
 		name = p_func.get_method().trim_prefix("_").trim_prefix("cmd_")
+	if not OS.is_debug_build() and _options.commands_disabled_in_release.has(name):
+		return
 	if _commands.has(name):
 		push_error("LimboConsole: Command already registered: " + p_name)
 		return


### PR DESCRIPTION
* Add an option to specify a list of commands that should be disabled in the release build (not registered).
* Disable `eval` by default.