### PR TITLE
Fix bound args

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -898,7 +898,12 @@ func _validate_callable(p_callable: Callable) -> bool:
 	if p_callable.is_standard() and method_info.is_empty():
 		push_error("LimboConsole: Couldn't find method info for: " + p_callable.get_method())
 		return false
-
+	if p_callable.is_custom() and not method_info.is_empty() \
+		and method_info.get("name") == "<anonymous lambda>" \
+		and p_callable.get_bound_arguments_count() > 0:
+			push_error("LimboConsole: bound anonymous functions are unsupported")
+			return false
+		
 	var ret := true
 	for arg in method_info.args:
 		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:

--- a/util.gd
+++ b/util.gd
@@ -24,18 +24,17 @@ static func bbcode_strip(p_text: String) -> String:
 
 
 static func get_method_info(p_callable: Callable) -> Dictionary:
-	var method_info: Dictionary
-	if p_callable.is_standard():
-		var method_list: Array[Dictionary]
-		if p_callable.get_object() is GDScript:
-			method_list = p_callable.get_object().get_script_method_list()
-		else:
-			method_list = p_callable.get_object().get_method_list()
-		for m in method_list:
-			if m.name == p_callable.get_method():
-				method_info = m
-				break
-	elif p_callable.is_custom():
+	var method_info: Dictionary	
+	var method_list: Array[Dictionary]
+	if p_callable.get_object() is GDScript:
+		method_list = p_callable.get_object().get_script_method_list()
+	else:
+		method_list = p_callable.get_object().get_method_list()
+	for m in method_list:
+		if m.name == p_callable.get_method():
+			method_info = m
+			break
+	if !method_info and p_callable.is_custom():
 		var args: Array
 		var default_args: Array
 		for i in p_callable.get_argument_count():


### PR DESCRIPTION
Fixes #37 which broke bound arguments from working since you are given a new Callable when adding bound arguments it is no longer considered a 'standard'. This adjusts the code so that it can differentiate between a 'standard' method that has bound arguments and an anonymous lambda function

This also adds validation that anonymous lambdas are not allowed to be registered with bound parameters. I spent quite some time trying to see if there was any way to view an anonymous lambda's expected arguments and was unsuccessful. The best I could do was see that arguments were bound into the callable and what those arguments are however, I had no way to pull the arguments that the lambda expects to receive since `get_method_list` won't return local anonymous lambda method information (it also won't if its a local named anonymous lambda). I think not allowing registration of anonymous lambdas is a better trade off than losing the ability to do what was requested in #8 and added in #27. 