### PR TITLE
Adds support for argument joining for methods with multiple parameters if all but first argument is bound

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -898,7 +898,12 @@ func _validate_callable(p_callable: Callable) -> bool:
 	if p_callable.is_standard() and method_info.is_empty():
 		push_error("LimboConsole: Couldn't find method info for: " + p_callable.get_method())
 		return false
-
+	if p_callable.is_custom() and not method_info.is_empty() \
+		and method_info.get("name") == "<anonymous lambda>" \
+		and p_callable.get_bound_arguments_count() > 0:
+			push_error("LimboConsole: bound anonymous functions are unsupported")
+			return false
+		
 	var ret := true
 	for arg in method_info.args:
 		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -656,7 +656,7 @@ func _parse_argv(p_argv: PackedStringArray, p_callable: Callable, r_args: Array)
 	var required_args: int = max_args - num_with_defaults
 
 	# Join all arguments into a single string if the callable accepts a single string argument.
-	if max_args == 1 and method_info.args[0].type == TYPE_STRING:
+	if max_args - num_bound_args == 1 and method_info.args[0].type == TYPE_STRING:
 		var a: String = " ".join(p_argv.slice(1))
 		if a.left(1) == '"' and a.right(1) == '"':
 			a = a.trim_prefix('"').trim_suffix('"')

--- a/util.gd
+++ b/util.gd
@@ -24,18 +24,17 @@ static func bbcode_strip(p_text: String) -> String:
 
 
 static func get_method_info(p_callable: Callable) -> Dictionary:
-	var method_info: Dictionary
-	if p_callable.is_standard():
-		var method_list: Array[Dictionary]
-		if p_callable.get_object() is GDScript:
-			method_list = p_callable.get_object().get_script_method_list()
-		else:
-			method_list = p_callable.get_object().get_method_list()
-		for m in method_list:
-			if m.name == p_callable.get_method():
-				method_info = m
-				break
-	elif p_callable.is_custom():
+	var method_info: Dictionary	
+	var method_list: Array[Dictionary]
+	if p_callable.get_object() is GDScript:
+		method_list = p_callable.get_object().get_script_method_list()
+	else:
+		method_list = p_callable.get_object().get_method_list()
+	for m in method_list:
+		if m.name == p_callable.get_method():
+			method_info = m
+			break
+	if !method_info and p_callable.is_custom():
 		var args: Array
 		var default_args: Array
 		for i in p_callable.get_argument_count():


### PR DESCRIPTION
Adds support for argument joining for methods with multiple parameters if all but first argument is bound. Mentioned missing in #27. This was branched off of #38. Without it this PR won't work

Example command to test with:

```python
LimboConsole.register_command(_bound_command_test_multi_arg.bind(32), "bound_command_multi_test", "Testing one input from command line one from bound argument")

static func _bound_command_test_multi_arg(val: String, num: int) -> void:
	LimboConsole.info("val: %s | num: %s" % [val, num])
```