### PR TITLE
Alias unwrapping + aliases for args

### DIFF
--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -58,13 +58,7 @@ static func cmd_alias(p_alias_expression: String = "") -> void:
 		end += 1
 	var command: String = p_alias_expression.substr(idx, end - idx).strip_edges()
 
-	if not command.is_valid_identifier():
-		LimboConsole.error("Invalid command identifier.")
-		_alias_usage()
-		return
-
 	# Note: It should be possible to create aliases for commands that are not yet registered.
-
 	idx = end
 	var args: String = p_alias_expression.substr(idx).strip_edges()
 	LimboConsole.remove_alias(alias)

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -290,9 +290,6 @@ func get_command_description(p_name: String) -> String:
 
 ## Registers an alias for a command (may include arguments).
 func add_alias(p_alias: String, p_command_to_run: String) -> void:
-	if not p_alias.is_valid_identifier():
-		error("Invalid alias identifier.")
-		return
 	# It should be possible to override commands and existing aliases.
 	# It should be possible to create aliases for commands that are not yet registered,
 	# because some commands may be registered by local-to-scene scripts.


### PR DESCRIPTION
Fixed #46 which will recursively apply aliases until it can no longer apply any aliases. Also has a default for exiting on max recursions. Also removes the constraint that an alias needs to be a valid identifier since arguments should also be able to be aliased such as numbers.


Commands to test with:

```python
static func register_commands() -> void:


	LimboConsole.register_command(add_item, "add_item", "adds items")
	LimboConsole.add_alias("add_long_swords", "add_item long_sword 1000")
	LimboConsole.add_alias("long_sword", "sword")
	
       # the following two lines result in recursive aliasing -- console should error when attempting to utilize these aliases
       # and defaults to the exact text put in
	LimboConsole.add_alias("alias1", "alias2") 
	LimboConsole.add_alias("alias2", "alias1")


static func add_item(name: String, amount: int):
	LimboConsole.info("Adding: %s %s" % [name, amount])
	pass
```

result:

![image](https://github.com/user-attachments/assets/9d6d2c30-7cfe-4482-bd30-664e6262d705)
