### PR TITLE
Add a simple subcommand support

### DIFF
--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -28,42 +28,14 @@ static func _alias_usage() -> void:
 	LimboConsole.info("Usage: %s alias_name command_to_run [args...]" % [LimboConsole.format_name("alias")])
 
 
-static func cmd_alias(p_alias_expression: String = "") -> void:
-	if p_alias_expression.is_empty():
+static func cmd_alias(p_alias: String, p_command: String) -> void:
+	if not Util.is_valid_command_sequence(p_alias):
+		LimboConsole.error("Invalid alias '%s'. Only space-separated identifiers allowed with letters, digits, or underscores, starting with non-digit." % [p_alias])
 		_alias_usage()
 		return
 
-	var sz: int = p_alias_expression.length()
-	var idx: int = 0
-
-	while idx < sz and p_alias_expression[idx] == ' ':
-		idx += 1
-	var end: int = idx
-
-	while end < sz and p_alias_expression[end] != ' ':
-		end += 1
-
-	var alias: String = p_alias_expression.substr(idx, end - idx)
-	if not alias.is_valid_identifier():
-		LimboConsole.error("Invalid alias identifier '%s'" % [alias])
-		_alias_usage()
-		return
-
-	idx = end
-	while idx < sz and p_alias_expression[idx] == ' ':
-		idx += 1
-
-	end = idx
-	while end < sz and p_alias_expression[end] != ' ':
-		end += 1
-	var command: String = p_alias_expression.substr(idx, end - idx).strip_edges()
-
-	# Note: It should be possible to create aliases for commands that are not yet registered.
-	idx = end
-	var args: String = p_alias_expression.substr(idx).strip_edges()
-	LimboConsole.remove_alias(alias)
-	LimboConsole.add_alias(alias, command + ' ' + args)
-	LimboConsole.info("Added %s: %s %s" % [LimboConsole.format_name(alias), command, args])
+	LimboConsole.info("Adding %s => %s" % [LimboConsole.format_name(p_alias), p_command])
+	LimboConsole.add_alias(p_alias, p_command)
 
 
 static func cmd_aliases() -> void:

--- a/builtin_commands.gd
+++ b/builtin_commands.gd
@@ -24,16 +24,7 @@ static func register_commands() -> void:
 	LimboConsole.add_argument_autocomplete_source("help", 1, LimboConsole.get_command_names.bind(true))
 
 
-static func _alias_usage() -> void:
-	LimboConsole.info("Usage: %s alias_name command_to_run [args...]" % [LimboConsole.format_name("alias")])
-
-
 static func cmd_alias(p_alias: String, p_command: String) -> void:
-	if not Util.is_valid_command_sequence(p_alias):
-		LimboConsole.error("Invalid alias '%s'. Only space-separated identifiers allowed with letters, digits, or underscores, starting with non-digit." % [p_alias])
-		_alias_usage()
-		return
-
 	LimboConsole.info("Adding %s => %s" % [LimboConsole.format_name(p_alias), p_command])
 	LimboConsole.add_alias(p_alias, p_command)
 

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -14,7 +14,7 @@ const Util := preload("res://addons/limbo_console/util.gd")
 const CommandHistory := preload("res://addons/limbo_console/command_history.gd")
 const HistoryGui := preload("res://addons/limbo_console/history_gui.gd")
 
-const _MAX_SUBCOMMANDS: int = 4
+const MAX_SUBCOMMANDS: int = 4
 
 ## If false, prevents console from being shown. Commands can still be executed from code.
 var enabled: bool = true:
@@ -685,7 +685,7 @@ func _parse_command_line(p_line: String) -> PackedStringArray:
 ## Joins recognized subcommands in the argument vector into a single
 ## space-separated command sequence at index zero.
 func _join_subcommands(p_argv: PackedStringArray) -> PackedStringArray:
-	for num_parts in range(_MAX_SUBCOMMANDS, 1, -1):
+	for num_parts in range(MAX_SUBCOMMANDS, 1, -1):
 		if p_argv.size() >= num_parts:
 			var cmd: String = ' '.join(p_argv.slice(0, num_parts))
 			if has_command(cmd) or has_alias(cmd):

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -14,6 +14,8 @@ const Util := preload("res://addons/limbo_console/util.gd")
 const CommandHistory := preload("res://addons/limbo_console/command_history.gd")
 const HistoryGui := preload("res://addons/limbo_console/history_gui.gd")
 
+const _MAX_SUBCOMMANDS: int = 4
+
 ## If false, prevents console from being shown. Commands can still be executed from code.
 var enabled: bool = true:
 	set(value):
@@ -44,8 +46,8 @@ var _entry_command_found_color: Color
 var _entry_command_not_found_color: Color
 
 var _options: ConsoleOptions
-var _commands: Dictionary # command_name => Callable
-var _aliases: Dictionary # alias_name => command_to_run: PackedStringArray
+var _commands: Dictionary # "command" => Callable, or "command sub1 sub2" =>  Callable
+var _aliases: Dictionary # "alias" => command_to_run: PackedStringArray (alias may contain subcommands)
 var _command_descriptions: Dictionary # command_name => description_text
 var _argument_autocomplete_sources: Dictionary # [command_name, arg_idx] => Callable
 var _history: CommandHistory
@@ -270,11 +272,12 @@ func print_line(p_line: String, p_stdout: bool = _options.print_to_stdout) -> vo
 		print(Util.bbcode_strip(p_line))
 
 
-## Registers a new command for the specified callable. [br]
-## Optionally, you can provide a name and a description.
+## Registers a callable as a command, with optional name and description.
+## Name can have up to 4 space-separated identifiers (e.g., "command sub1 sub2 sub3"),
+## using letters, digits, or underscores, starting with a non-digit.
 func register_command(p_func: Callable, p_name: String = "", p_desc: String = "") -> void:
-	if p_name and not p_name.is_valid_ascii_identifier():
-		push_error("LimboConsole: Failed to register command: %s. A command must be a valid ascii identifier" % [p_name])
+	if p_name and not Util.is_valid_command_sequence(p_name):
+		push_error("LimboConsole: Failed to register command: %s. Name can have up to 4 space-separated identifiers, using letters, digits, or underscores, starting with non-digit." % [p_name])
 		return
 
 	if not _validate_callable(p_func):
@@ -333,7 +336,9 @@ func get_command_description(p_name: String) -> String:
 	return _command_descriptions.get(p_name, "")
 
 
-## Registers an alias for a command (may include arguments).
+## Registers an alias for command line. [br]
+## Alias may contain space-separated parts, e.g. "command sub1" which must match
+## against two subsequent arguments on the command line.
 func add_alias(p_alias: String, p_command_to_run: String) -> void:
 	# It should be possible to override commands and existing aliases.
 	# It should be possible to create aliases for commands that are not yet registered,
@@ -389,7 +394,7 @@ func execute_command(p_command_line: String, p_silent: bool = false) -> void:
 		return
 
 	var argv: PackedStringArray = _parse_command_line(p_command_line)
-	var expanded_argv: PackedStringArray = _expand_alias(argv)
+	var expanded_argv: PackedStringArray = _join_subcommands(_expand_alias(argv))
 	var command_name: String = expanded_argv[0]
 	var command_args: Array = []
 
@@ -677,6 +682,18 @@ func _parse_command_line(p_line: String) -> PackedStringArray:
 	return argv
 
 
+## Joins recognized subcommands in the argument vector into a single
+## space-separated command sequence at index zero.
+func _join_subcommands(p_argv: PackedStringArray) -> PackedStringArray:
+	for num_parts in range(_MAX_SUBCOMMANDS, 1, -1):
+		if p_argv.size() >= num_parts:
+			var cmd: String = ' '.join(p_argv.slice(0, num_parts))
+			if has_command(cmd) or has_alias(cmd):
+				var argv: PackedStringArray = [cmd]
+				return argv + p_argv.slice(num_parts)
+	return p_argv
+
+
 ## Substitutes an array of strings with its real command in argv.
 ## Will recursively expand aliases until no aliases are left.
 func _expand_alias(p_argv: PackedStringArray) -> PackedStringArray:
@@ -685,6 +702,7 @@ func _expand_alias(p_argv: PackedStringArray) -> PackedStringArray:
 	const max_depth: int = 1000
 	var current_depth: int = 0
 	while not argv.is_empty() and current_depth != max_depth:
+		argv = _join_subcommands(argv)
 		var current: String = argv[0]
 		argv.remove_at(0)
 		var alias_argv: PackedStringArray = _aliases.get(current, [])

--- a/util.gd
+++ b/util.gd
@@ -106,3 +106,14 @@ static func _calculate_osa_distance(s1: String, s2: String) -> int:
 		row1 = row2
 		row2 = tmp
 	return row1[s2_len]
+
+
+## Returns true, if a string is constructed of one or more space-separated valid
+## command identifiers ("command" or "command sub1 sub2").
+## A valid command identifier may contain only letters, digits, and underscores (_),
+## and the first character may not be a digit.
+static func is_valid_command_sequence(p_string: String) -> bool:
+	for part in p_string.split(' '):
+		if not part.is_valid_ascii_identifier():
+			return false
+	return true


### PR DESCRIPTION
This PR adds simple subcommand support. It currently lacks autocompletion or subcommand syntax highlighting; otherwise, it works well in my tests, including with `commands` and `help`. The rest can be added in follow-up PRs.

Since `alias` command can now be used with subcommands, it's signature was changed from a single string argument to two string arguments. It's now possible to create aliases for subcommands, for example: 
```
alias "player hp" gethp
```

Resolves #18
Supersedes #48 
