### PR TITLE
Add history dirty state tracking, and save on close

### DIFF
--- a/command_history.gd
+++ b/command_history.gd
@@ -8,6 +8,7 @@ const HISTORY_FILE := "user://limbo_console_history.log"
 var _entries: PackedStringArray
 var _hist_idx = -1
 var _iterators: Array[WrappingIterator]
+var _is_dirty: bool = false
 
 
 func push_entry(p_entry: String) -> void:
@@ -21,6 +22,7 @@ func _push_entry(p_entry: String) -> void:
 		# Duplicate commands not allowed in history.
 		_entries.remove_at(idx)
 	_entries.append(p_entry)
+	_is_dirty = true
 
 
 func get_entry(p_index: int) -> String:
@@ -61,9 +63,12 @@ func load(p_path: String = HISTORY_FILE) -> void:
 			_push_entry(line)
 	file.close()
 	_reset_iterators()
+	_is_dirty = false
 
 
 func save(p_path: String = HISTORY_FILE) -> void:
+	if not _is_dirty:
+		return
 	var file := FileAccess.open(p_path, FileAccess.WRITE)
 	if not file:
 		push_error("LimboConsole: Failed to save console history to file: ", p_path)
@@ -71,6 +76,7 @@ func save(p_path: String = HISTORY_FILE) -> void:
 	for line in _entries:
 		file.store_line(line)
 	file.close()
+	_is_dirty = false
 
 
 ## Searches history and returns an array starting with most relevant entries.

--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -200,6 +200,8 @@ func close_console() -> void:
 		_is_open = false
 		set_process(true)
 		_history_gui.visible = false
+		if _options.persist_history:
+			_history.save()
 		# _hide_console() is called in _process()
 
 


### PR DESCRIPTION
I added the extra save check to the close_console() function rather than the hide_console part to hopefully still save if the user pressed the close console button but then force closes the game before the close animation finishes.

Should close #33