### PR TITLE
Typing an invalid subcommand will display the correct help text when the text is a command or a subcommand 

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -421,7 +421,7 @@ func execute_command(p_command_line: String, p_silent: bool = false) -> void:
 		if failed:
 			_suggest_argument_corrections(expanded_argv)
 	else:
-		usage(argv[0])
+		usage(command_name)
 	if _options.sparse_mode:
 		print_line("")
 	_silent = false


### PR DESCRIPTION
When I adding some commands to my game today I noticed that the console wasn't displaying the correct usage/help text when failing to provide an argument. This fixes that so a subcommand's usage/help text shows

before:
![image](https://github.com/user-attachments/assets/1d3b0235-06b0-46ad-92c1-87b7cf6c327c)

after:
![image](https://github.com/user-attachments/assets/7c479034-d620-4c81-9f32-5b3479871910)
