### PR TITLE
change enter/exit_tree to enable/disable_plugin

### DIFF
--- a/plugin.gd
+++ b/plugin.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 const ConsoleOptions := preload("res://addons/limbo_console/console_options.gd")
 const ConfigMapper := preload("res://addons/limbo_console/config_mapper.gd")
 
-func _enter_tree() -> void:
+func _enable_plugin() -> void:
 	add_autoload_singleton("LimboConsole", "res://addons/limbo_console/limbo_console.gd")
 
 	# Sync config file (create if not exists)
@@ -53,5 +53,5 @@ func _enter_tree() -> void:
 		ProjectSettings.save()
 
 
-func _exit_tree() -> void:
+func _disable_plugin() -> void:
 	remove_autoload_singleton("LimboConsole")


### PR DESCRIPTION
Using add_autoload_singleton on _enter_tree puts the godot project on an unsaved changes state, changing to _enable_plugin instead eliminates this problem