### PR TITLE
add bash-like autocomplete mode

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -54,6 +54,7 @@ var _argument_autocomplete_sources: Dictionary # [command_name, arg_idx] => Call
 var _history: CommandHistory
 var _history_iter: CommandHistory.WrappingIterator
 var _autocomplete_matches: PackedStringArray
+var _autocomplete_counter := 0
 var _eval_inputs: Dictionary
 var _silent: bool = false
 var _was_already_paused: bool = false
@@ -117,10 +118,12 @@ func _handle_command_input(p_event: InputEvent) -> void:
 		_fill_entry(_history_iter.next())
 		_clear_autocomplete()
 		_update_autocomplete()
-	elif p_event.is_action_pressed("limbo_auto_complete_reverse"):
+	elif p_event.is_action_pressed("limbo_auto_complete_reverse", false, true):
 		_reverse_autocomplete()
-	elif p_event.keycode == KEY_TAB:
+	elif p_event.is_action_pressed("limbo_auto_complete_forward", false, true):
 		_autocomplete()
+	elif p_event.is_action_pressed("limbo_auto_complete_with_list", false, true):
+		_autocomplete_with_list()
 	elif p_event.keycode == KEY_PAGEUP:
 		var scroll_bar: VScrollBar = _output.get_v_scroll_bar()
 		scroll_bar.value -= scroll_bar.page
@@ -272,6 +275,19 @@ func print_line(p_line: String, p_stdout: bool = _options.print_to_stdout) -> vo
 	_output.text += p_line + "\n"
 	if p_stdout:
 		print(Util.bbcode_strip(p_line))
+
+
+## Prints array of string in constant length columns
+func print_in_columns(strings, separator_size = 3):
+	var column_size = 0
+	for s in strings:
+		if s.length() > column_size:
+			column_size = s.length()
+	column_size += separator_size
+	var string = ""
+	for s in strings:
+		string += s.rpad(column_size)
+	print_line(string)
 
 
 ## Registers a callable as a command, with optional name and description.
@@ -853,6 +869,31 @@ func _reverse_autocomplete():
 		match_str = _autocomplete_matches[_autocomplete_matches.size() - 1]
 		_fill_entry(match_str)
 		_update_autocomplete()
+
+
+## Auto-completes with propositions list on second pressing TAB and without cycles
+func _autocomplete_with_list() -> void:
+	var matches_count = _autocomplete_matches.size()
+	if matches_count == 0:
+		_autocomplete_counter = 0
+		return
+	elif matches_count == 1:
+		var match_str: String = _autocomplete_matches[0]
+		_fill_entry(match_str + " ")
+		_autocomplete_matches.clear()
+		_update_autocomplete()
+		_autocomplete_counter = 0
+	else:
+		_autocomplete_counter += 1
+		if _autocomplete_counter == 2:
+			_autocomplete_counter = 0
+			var argc = _entry.text.split(" ").size() - 1
+			var sugestions = []
+			for sugestion in _autocomplete_matches:
+				var sugestion_argv = sugestion.split(" ", true, argc)
+				if sugestion_argv.size() > argc:
+					sugestions.append(sugestion_argv[argc])
+			print_in_columns(sugestions)
 
 
 ## Updates autocomplete suggestions and hint based on user input.

--- a/plugin.gd
+++ b/plugin.gd
@@ -4,52 +4,38 @@ extends EditorPlugin
 const ConsoleOptions := preload("res://addons/limbo_console/console_options.gd")
 const ConfigMapper := preload("res://addons/limbo_console/config_mapper.gd")
 
+func _add_input_action(name : String, keycode : Key, shift := false, ctrl := false) -> int:
+	if not ProjectSettings.has_setting("input/" + name):
+		print("LimboConsole: Adding \"" + name + "\" input action to project settings...")
+
+		var key_event := InputEventKey.new()
+		key_event.keycode = keycode
+		key_event.shift_pressed = shift
+		key_event.ctrl_pressed = ctrl
+
+		ProjectSettings.set_setting("input/" + name, {
+			"deadzone": 0.5,
+			"events": [key_event],
+		})
+		return 1
+	return 0
+
 func _enable_plugin() -> void:
 	add_autoload_singleton("LimboConsole", "res://addons/limbo_console/limbo_console.gd")
 
 	# Sync config file (create if not exists)
 	var console_options := ConsoleOptions.new()
-	var do_project_setting_save: bool = false
 	ConfigMapper.load_from_config(console_options)
 	ConfigMapper.save_to_config(console_options)
 
-	if not ProjectSettings.has_setting("input/limbo_console_toggle"):
-		print("LimboConsole: Adding \"limbo_console_toggle\" input action to project settings...")
+	var created_actions: int = 0
+	created_actions += _add_input_action("limbo_console_toggle", KEY_QUOTELEFT)
+	created_actions += _add_input_action("limbo_auto_complete_forward", KEY_TAB, false, false)
+	created_actions += _add_input_action("limbo_auto_complete_reverse", KEY_TAB, true, false)
+	created_actions += _add_input_action("limbo_auto_complete_with_list", KEY_TAB, false, true)
+	created_actions += _add_input_action("limbo_console_search_history", KEY_R)
 
-		var key_event := InputEventKey.new()
-		key_event.keycode = KEY_QUOTELEFT
-
-		ProjectSettings.set_setting("input/limbo_console_toggle", {
-			"deadzone": 0.5,
-			"events": [key_event],
-		})
-		do_project_setting_save = true
-		
-	if not ProjectSettings.has_setting("input/limbo_auto_complete_reverse"):
-		print("LimboConsole: Adding \"limbo_auto_complete_reverse\" input action to project settings...")
-		var key_event = InputEventKey.new()
-		key_event.keycode = KEY_TAB
-		key_event.shift_pressed = true
-		
-		ProjectSettings.set_setting("input/limbo_auto_complete_reverse", {
-			"deadzone": 0.5,
-			"events": [key_event],
-		})
-		do_project_setting_save = true
-	
-	if not ProjectSettings.has_setting("input/limbo_console_search_history"):
-		print("LimboConsole: Adding \"limbo_console_search_history\" input action to project settings...")
-		var key_event = InputEventKey.new()
-		key_event.keycode = KEY_R
-		key_event.ctrl_pressed = true
-		
-		ProjectSettings.set_setting("input/limbo_console_search_history", {
-			"deadzone": 0.5,
-			"events": [key_event],
-		})
-		do_project_setting_save = true
-		
-	if do_project_setting_save:
+	if created_actions > 0:
 		ProjectSettings.save()
 
 


### PR DESCRIPTION
* Add autocomplete with list of suggestions mode (default Ctrl+Tab):
   * If the complement is unambiguous, then a single keystroke causes the complement.
   * If the complement is ambiguous, then a single keystroke does nothing; the next keystroke displays a list of suggestions.
* Use `is_action_pressed` with `exact_match=true` for all autocomplete actions
   * This allow the user to remap this mode to Tab and cycle mode to Ctrl+Tab
* Add `print_in_columns` function for printing list of suggestions
   * It print single line, but due to RichTextLabel this ensures the correct column arrangement even when changing the window size.
* Add `_add_input_action` in `plugin.gd` to remove code duplication.