### PR TITLE
Relax restrictions on command identifiers

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -275,11 +275,11 @@ func print_line(p_line: String, p_stdout: bool = _options.print_to_stdout) -> vo
 
 
 ## Registers a callable as a command, with optional name and description.
-## Name can have up to 4 space-separated identifiers (e.g., "command sub1 sub2 sub3"),
-## using letters, digits, or underscores, starting with a non-digit.
+## Name can have up to 4 space-separated identifiers (e.g., "command sub1 sub2 sub3").
+## A valid command identifier may contain only letters, digits, periods, and underscores (_).
 func register_command(p_func: Callable, p_name: String = "", p_desc: String = "") -> void:
 	if p_name and not Util.is_valid_command_sequence(p_name):
-		push_error("LimboConsole: Failed to register command: %s. Name can have up to 4 space-separated identifiers, using letters, digits, or underscores, starting with non-digit." % [p_name])
+		push_error("LimboConsole: Failed to register command: %s. Name can have up to 4 space-separated identifiers each containing only letters, digits, periods, and underscores (_)." % [p_name])
 		return
 
 	if not _validate_callable(p_func):

--- a/util.gd
+++ b/util.gd
@@ -109,11 +109,14 @@ static func _calculate_osa_distance(s1: String, s2: String) -> int:
 
 
 ## Returns true, if a string is constructed of one or more space-separated valid
-## command identifiers ("command" or "command sub1 sub2").
-## A valid command identifier may contain only letters, digits, and underscores (_),
-## and the first character may not be a digit.
+## command identifiers ("command" or "command sub1 sub2"). 
+## A valid command identifier may contain only letters, digits, periods, and 
+## underscores (_).
 static func is_valid_command_sequence(p_string: String) -> bool:
+	var regex = RegEx.new()
+	regex.compile("^[A-Za-z0-9_\\.]+$")
+	
 	for part in p_string.split(' '):
-		if not part.is_valid_ascii_identifier():
+		if not regex.search(part):
 			return false
 	return true


### PR DESCRIPTION
Allows command identifiers to have more flexible names:
* Can contain periods
* Can begin with any otherwise valid character

Fixes lucky number #77 