### PR TITLE
Implement pause-on-scroll scroll-following behavior

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -599,7 +599,10 @@ func _build_gui() -> void:
 				correct_scroll.call_deferred()
 		else:
 			# Scroll bar is done moving from prints, so it must have been moved by user. Thus, we update the last value
-			scroll_history["last_value"] = scroll_bar.value / (scroll_bar.max_value - scroll_bar.page)
+			if scroll_bar.max_value - scroll_bar.page > 0:
+				scroll_history["last_value"] = scroll_bar.value / (scroll_bar.max_value - scroll_bar.page)
+			else:
+				scroll_history["last_value"] = 1.0
 	)
 
 	_entry = CommandEntry.new()


### PR DESCRIPTION
Implements #82 so that the user may scroll to a position and temporarily disable the scroll-follow behavior until scrolling back to the most recent message. I only used the plugin on 4.5+, so it is possible that there was a regression between 4.2 and 4.6.