### PR TITLE
Dynamic plugin version from Github Actions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Initialize version
         shell: bash

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Draft Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ github.ref }}
+          tag: ${{ env.VERSION_TAG }}
           name: ${{ env.VERSION_TAG }}
           body: ${{ steps.changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -24,6 +24,7 @@ jobs:
           VERSION_TAG="$( (git describe --tags --exact-match HEAD || git rev-parse --short HEAD) | sed 's/\(.*\)-\(.*\)/\1.\2/g' )"
           VERSION=${VERSION_TAG#v}
           echo "VERSION_TAG=${VERSION_TAG}" >> "$GITHUB_ENV"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Update plugin version
         shell: bash

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,27 +21,35 @@ jobs:
       - name: Initialize version
         shell: bash
         run: |
-          echo "VERSION=$( (git describe --tags --exact-match HEAD || git rev-parse --short HEAD) | sed 's/\(.*\)-\(.*\)/\1.\2/g' )" >> "$GITHUB_ENV"
+          VERSION_TAG="$( (git describe --tags --exact-match HEAD || git rev-parse --short HEAD) | sed 's/\(.*\)-\(.*\)/\1.\2/g' )"
+          VERSION=${VERSION_TAG#v}
+          echo "VERSION_TAG=${VERSION_TAG}" >> "$GITHUB_ENV"
+
+      - name: Update plugin version
+        shell: bash
+        run: sed -i 's|version="<VERSION>"|version="${VERSION}"|g' plugin.cfg
 
       - name: Create artifact
         shell: bash
         run: |
+          mkdir -p temp/addons/limbo_console/
+          cp -r *.gd *.cfg *.uid res/ temp/addons/limbo_console/
           mkdir out/
-          git archive --prefix="addons/limbo_console/" --output="out/limbo_console_${VERSION}.zip" ${{ github.ref }}
+          cd temp && zip -r "../out/limbo_console_${VERSION_TAG}.zip" addons/
 
       - name: Generate changelog
         id: changelog
         uses: metcalfc/changelog-generator@v4.3.1
         with:
-          myToken: ${{ secrets.GITHUB_TOKEN }}
+          myToken: ${{ secrets.GH_TOKEN }}
           base-ref: ${{ inputs.base-ref }}
 
       - name: Draft Release
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ github.ref }}
-          name: ${{ env.VERSION }}
+          name: ${{ env.VERSION_TAG }}
           body: ${{ steps.changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
-          artifacts: "out/limbo_console_${{ env.VERSION }}.zip"
+          artifacts: "out/limbo_console_${{ env.VERSION_TAG }}.zip"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Update plugin version
         shell: bash
-        run: sed -i 's|version="<VERSION>"|version="${VERSION}"|g' plugin.cfg
+        run: sed -i "s|version=\"<VERSION>\"|version=\"${VERSION}\"|g" plugin.cfg
 
       - name: Create artifact
         shell: bash
@@ -47,7 +47,7 @@ jobs:
       - name: Draft Release
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ env.VERSION_TAG }}
+          tag: ${{ github.ref }}
           name: ${{ env.VERSION_TAG }}
           body: ${{ steps.changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -3,5 +3,5 @@
 name="LimboConsole"
 description="Yet another in-game console with a simple command interpreter."
 author="Serhii Snitsaruk"
-version="0.4.1"
+version="<VERSION>"
 script="plugin.gd"


### PR DESCRIPTION
Version in plugin.cfg seems to have been updated manually in the past 2 years ago. Current version for 0.7.0 in-engine is reporting as 0.4.1. This will update version in CI/CD so it doesn't need to be maintained to match releases.

Please note that in setting up my repository, it looks like secrets can no longer start with 'GITHUB_'. As a result, I've renamed GITHUB_TOKEN to GH_TOKEN causing a breaking change.