### PR TITLE
Allow binding functions with StringName arguments

### DIFF
--- a/limbo_console.gd
+++ b/limbo_console.gd
@@ -819,7 +819,7 @@ func _parse_argv(p_argv: PackedStringArray, p_callable: Callable, r_args: Array)
 func _are_compatible_types(p_expected_type: int, p_parsed_type: int) -> bool:
 	return p_expected_type == p_parsed_type or \
 		p_expected_type == TYPE_NIL or \
-		p_expected_type == TYPE_STRING or \
+		p_expected_type == TYPE_STRING or p_expected_type == TYPE_STRING_NAME or \
 		(p_expected_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT] and p_parsed_type in [TYPE_BOOL, TYPE_INT, TYPE_FLOAT]) or \
 		(p_expected_type in [TYPE_VECTOR2, TYPE_VECTOR2I] and p_parsed_type in [TYPE_VECTOR2, TYPE_VECTOR2I]) or \
 		(p_expected_type in [TYPE_VECTOR3, TYPE_VECTOR3I] and p_parsed_type in [TYPE_VECTOR3, TYPE_VECTOR3I]) or \
@@ -1071,7 +1071,7 @@ func _validate_callable(p_callable: Callable) -> bool:
 
 	var ret := true
 	for arg in method_info.args:
-		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:
+		if not arg.type in [TYPE_NIL, TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING, TYPE_STRING_NAME, TYPE_VECTOR2, TYPE_VECTOR2I, TYPE_VECTOR3, TYPE_VECTOR3I, TYPE_VECTOR4, TYPE_VECTOR4I]:
 			push_error("LimboConsole: Unsupported argument type: %s is %s" % [arg.name, type_string(arg.type)])
 			ret = false
 	return ret


### PR DESCRIPTION
LimboConsole rejects command registration of functions with StringName arguments. String to StringName conversion is trivial and transparent.
```
LimboConsole.register_command(func_with_stringname_arg, "command1")
```