### PR TITLE
Auto-include console config on project export

### DIFF
--- a/export_plugin.gd
+++ b/export_plugin.gd
@@ -1,0 +1,17 @@
+@tool
+extends EditorExportPlugin
+## Ensures configuration file is exported.
+
+const ConsoleOptions := preload("res://addons/limbo_console/console_options.gd")
+
+
+func _get_name() -> String:
+	return "LimboConsoleExportPlugin"
+
+
+func _export_begin(features: PackedStringArray, is_debug: bool, path: String, flags: int) -> void:
+	var file := FileAccess.open(ConsoleOptions.CONFIG_PATH, FileAccess.READ)
+	if file:
+		add_file(ConsoleOptions.CONFIG_PATH, file.get_buffer(file.get_length()), false)
+	else:
+		printerr("LimboConsole: Config file not found - skipped.")

--- a/export_plugin.gd.uid
+++ b/export_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://c06kr515xdyjc

--- a/plugin.gd
+++ b/plugin.gd
@@ -3,6 +3,20 @@ extends EditorPlugin
 
 const ConsoleOptions := preload("res://addons/limbo_console/console_options.gd")
 const ConfigMapper := preload("res://addons/limbo_console/config_mapper.gd")
+const ConsoleExportPlugin := preload("res://addons/limbo_console/export_plugin.gd")
+
+var _export_plugin: EditorExportPlugin
+
+
+func _enter_tree() -> void:
+	if _export_plugin == null:
+		_export_plugin = ConsoleExportPlugin.new()
+	add_export_plugin(_export_plugin)
+
+
+func _exit_tree() -> void:
+	remove_export_plugin(_export_plugin)
+
 
 func _enable_plugin() -> void:
 	add_autoload_singleton("LimboConsole", "res://addons/limbo_console/limbo_console.gd")
@@ -24,31 +38,31 @@ func _enable_plugin() -> void:
 			"events": [key_event],
 		})
 		do_project_setting_save = true
-		
+
 	if not ProjectSettings.has_setting("input/limbo_auto_complete_reverse"):
 		print("LimboConsole: Adding \"limbo_auto_complete_reverse\" input action to project settings...")
 		var key_event = InputEventKey.new()
 		key_event.keycode = KEY_TAB
 		key_event.shift_pressed = true
-		
+
 		ProjectSettings.set_setting("input/limbo_auto_complete_reverse", {
 			"deadzone": 0.5,
 			"events": [key_event],
 		})
 		do_project_setting_save = true
-	
+
 	if not ProjectSettings.has_setting("input/limbo_console_search_history"):
 		print("LimboConsole: Adding \"limbo_console_search_history\" input action to project settings...")
 		var key_event = InputEventKey.new()
 		key_event.keycode = KEY_R
 		key_event.ctrl_pressed = true
-		
+
 		ProjectSettings.set_setting("input/limbo_console_search_history", {
 			"deadzone": 0.5,
 			"events": [key_event],
 		})
 		do_project_setting_save = true
-		
+
 	if do_project_setting_save:
 		ProjectSettings.save()
 


### PR DESCRIPTION
Auto-add `res://addons/limbo_console.cfg` to exported PCK. Previously, this had to be done manually via export option includes.
- Closes #87 